### PR TITLE
feat: allow to auto-provision oidc users

### DIFF
--- a/crates/core/src/app_setting/mod.rs
+++ b/crates/core/src/app_setting/mod.rs
@@ -2,7 +2,7 @@ pub mod model;
 pub mod repository;
 pub mod service;
 
-pub use model::{AppSetting, NewAppSetting};
+pub use model::{AppSetting, NewAppSetting, OidcProvisioningDefaults};
 pub use repository::AppSettingRepository;
 pub use service::AppSettingService;
 pub(crate) use service::AppSettingServiceImpl;

--- a/crates/core/src/app_setting/model.rs
+++ b/crates/core/src/app_setting/model.rs
@@ -1,3 +1,5 @@
+use crate::types::Capabilities;
+
 #[derive(Debug, Clone)]
 pub struct AppSetting {
     pub key: String,
@@ -8,4 +10,22 @@ pub struct AppSetting {
 pub struct NewAppSetting {
     pub key: String,
     pub value: String,
+}
+
+/// Default parameters applied to accounts auto-provisioned on first OIDC login.
+///
+/// Persisted as three separate `oidc.provisioning.*` app-setting rows (see
+/// [`AppSettingService::oidc_provisioning_defaults`]). Library tokens are kept
+/// as strings and round-tripped verbatim — the caller parses them into
+/// `LibraryToken` when assigning libraries.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct OidcProvisioningDefaults {
+    /// Capabilities granted to the provisioned user. The role is expressed via
+    /// `Capability::Admin`; `Capability::SuperAdmin` is never allowed here.
+    pub capabilities: Capabilities,
+    /// Library tokens to assign to the provisioned user.
+    pub library_tokens: Vec<String>,
+    /// Default library token — must be one of `library_tokens`. `None` falls
+    /// back to the All Books library at resolution time.
+    pub default_library: Option<String>,
 }

--- a/crates/core/src/app_setting/service.rs
+++ b/crates/core/src/app_setting/service.rs
@@ -2,12 +2,15 @@ use std::sync::Arc;
 
 use crate::{
     Error,
-    app_setting::{AppSetting, NewAppSetting},
+    app_setting::{AppSetting, NewAppSetting, OidcProvisioningDefaults},
     repository::RepositoryService,
     with_read_only_transaction, with_transaction,
 };
 
 const MOBI_ENABLED_KEY: &str = "enrichment.mobi_enabled";
+const OIDC_PROVISIONING_CAPABILITIES_KEY: &str = "oidc.provisioning.capabilities";
+const OIDC_PROVISIONING_LIBRARY_TOKENS_KEY: &str = "oidc.provisioning.library_tokens";
+const OIDC_PROVISIONING_DEFAULT_LIBRARY_KEY: &str = "oidc.provisioning.default_library";
 
 #[cfg_attr(any(test, feature = "test-support"), mockall::automock)]
 #[async_trait::async_trait]
@@ -15,6 +18,8 @@ pub trait AppSettingService: Send + Sync {
     async fn get(&self, key: &str) -> Result<Option<AppSetting>, Error>;
     async fn set(&self, key: &str, value: &str) -> Result<AppSetting, Error>;
     async fn mobi_enabled(&self) -> Result<bool, Error>;
+    async fn oidc_provisioning_defaults(&self) -> Result<OidcProvisioningDefaults, Error>;
+    async fn set_oidc_provisioning_defaults(&self, defaults: &OidcProvisioningDefaults) -> Result<(), Error>;
 }
 
 pub(crate) struct AppSettingServiceImpl {
@@ -46,6 +51,40 @@ impl AppSettingService for AppSettingServiceImpl {
         let result = self.get(MOBI_ENABLED_KEY).await?;
         Ok(result.is_some_and(|s| s.value == "true"))
     }
+
+    async fn oidc_provisioning_defaults(&self) -> Result<OidcProvisioningDefaults, Error> {
+        let capabilities = match self.get(OIDC_PROVISIONING_CAPABILITIES_KEY).await? {
+            Some(s) => serde_json::from_str(&s.value).map_err(|e| Error::Infrastructure(e.to_string()))?,
+            None => crate::types::Capabilities::default(),
+        };
+        let library_tokens: Vec<String> = match self.get(OIDC_PROVISIONING_LIBRARY_TOKENS_KEY).await? {
+            Some(s) => serde_json::from_str(&s.value).map_err(|e| Error::Infrastructure(e.to_string()))?,
+            None => Vec::new(),
+        };
+        let default_library = self
+            .get(OIDC_PROVISIONING_DEFAULT_LIBRARY_KEY)
+            .await?
+            .map(|s| s.value)
+            .filter(|v| !v.is_empty());
+
+        Ok(OidcProvisioningDefaults {
+            capabilities,
+            library_tokens,
+            default_library,
+        })
+    }
+
+    async fn set_oidc_provisioning_defaults(&self, defaults: &OidcProvisioningDefaults) -> Result<(), Error> {
+        let capabilities = serde_json::to_string(&defaults.capabilities).map_err(|e| Error::Infrastructure(e.to_string()))?;
+        let library_tokens = serde_json::to_string(&defaults.library_tokens).map_err(|e| Error::Infrastructure(e.to_string()))?;
+
+        self.set(OIDC_PROVISIONING_CAPABILITIES_KEY, &capabilities).await?;
+        self.set(OIDC_PROVISIONING_LIBRARY_TOKENS_KEY, &library_tokens).await?;
+        self.set(OIDC_PROVISIONING_DEFAULT_LIBRARY_KEY, defaults.default_library.as_deref().unwrap_or(""))
+            .await?;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -55,7 +94,8 @@ mod tests {
     use super::{AppSettingService, AppSettingServiceImpl};
     use crate::{
         Error, RepositoryError,
-        app_setting::{AppSetting, repository::MockAppSettingRepository},
+        app_setting::{AppSetting, OidcProvisioningDefaults, repository::MockAppSettingRepository},
+        types::Capability,
     };
 
     fn fake_setting(key: &str, value: &str) -> AppSetting {
@@ -165,5 +205,102 @@ mod tests {
         let setting = result.unwrap();
         assert_eq!(setting.key, "some-key");
         assert_eq!(setting.value, "some-value");
+    }
+
+    // ─── oidc_provisioning_defaults ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn oidc_provisioning_defaults_empty_when_unset() {
+        let mut repo = MockAppSettingRepository::new();
+        repo.expect_get().returning(|_, _| Box::pin(async { Ok(None) }));
+        let svc = create_service(repo);
+
+        let result = svc.oidc_provisioning_defaults().await.unwrap();
+
+        assert!(result.capabilities.is_empty());
+        assert!(result.library_tokens.is_empty());
+        assert!(result.default_library.is_none());
+    }
+
+    #[tokio::test]
+    async fn oidc_provisioning_defaults_parses_stored_values() {
+        let mut repo = MockAppSettingRepository::new();
+        repo.expect_get().returning(|_, key| {
+            let key = key.to_owned();
+            Box::pin(async move {
+                let value = match key.as_str() {
+                    "oidc.provisioning.capabilities" => Some(r#"["EditBook","Admin"]"#),
+                    "oidc.provisioning.library_tokens" => Some(r#"["LB_AAAAAAAAAAAA1","LB_BBBBBBBBBBBB2"]"#),
+                    "oidc.provisioning.default_library" => Some("LB_AAAAAAAAAAAA1"),
+                    _ => None,
+                };
+                Ok(value.map(|v| AppSetting { key, value: v.to_owned() }))
+            })
+        });
+        let svc = create_service(repo);
+
+        let result = svc.oidc_provisioning_defaults().await.unwrap();
+
+        assert!(result.capabilities.contains(&Capability::EditBook));
+        assert!(result.capabilities.contains(&Capability::Admin));
+        assert_eq!(result.library_tokens, vec!["LB_AAAAAAAAAAAA1", "LB_BBBBBBBBBBBB2"]);
+        assert_eq!(result.default_library.as_deref(), Some("LB_AAAAAAAAAAAA1"));
+    }
+
+    #[tokio::test]
+    async fn oidc_provisioning_defaults_treats_empty_default_as_none() {
+        let mut repo = MockAppSettingRepository::new();
+        repo.expect_get().returning(|_, key| {
+            let key = key.to_owned();
+            Box::pin(async move {
+                let value = if key == "oidc.provisioning.default_library" { Some("") } else { None };
+                Ok(value.map(|v: &str| AppSetting { key, value: v.to_owned() }))
+            })
+        });
+        let svc = create_service(repo);
+
+        let result = svc.oidc_provisioning_defaults().await.unwrap();
+
+        assert!(result.default_library.is_none());
+    }
+
+    #[tokio::test]
+    async fn oidc_provisioning_defaults_propagates_error() {
+        let mut repo = MockAppSettingRepository::new();
+        repo.expect_get()
+            .returning(|_, _| Box::pin(async { Err(Error::RepositoryError(RepositoryError::Database("db error".into()))) }));
+        let svc = create_service(repo);
+
+        let result = svc.oidc_provisioning_defaults().await;
+
+        assert!(matches!(result, Err(Error::RepositoryError(RepositoryError::Database(_)))));
+    }
+
+    // ─── set_oidc_provisioning_defaults ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn set_oidc_provisioning_defaults_writes_three_keys() {
+        use std::collections::HashSet;
+
+        let mut repo = MockAppSettingRepository::new();
+        repo.expect_set().times(3).returning(|_, setting| {
+            Box::pin(async move {
+                Ok(AppSetting {
+                    key: setting.key,
+                    value: setting.value,
+                })
+            })
+        });
+        let svc = create_service(repo);
+
+        let defaults = OidcProvisioningDefaults {
+            capabilities: HashSet::from([Capability::EditBook]),
+            library_tokens: vec!["LB_AAAAAAAAAAAA1".to_string()],
+            default_library: Some("LB_AAAAAAAAAAAA1".to_string()),
+        };
+
+        let result = svc.set_oidc_provisioning_defaults(&defaults).await;
+
+        assert!(result.is_ok());
     }
 }

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -60,6 +60,13 @@ pub struct OidcConfig {
     /// Login page button text. Defaults to "Sign in with SSO".
     /// Environment variable: `BOOKBOSS__OIDC__BUTTON_LABEL`
     pub button_label: Option<String>,
+
+    /// When `true`, an OIDC login whose email matches no existing BookBoss user
+    /// auto-provisions a new account using the defaults configured under
+    /// Settings > Users. When `false` (the default), such logins are rejected.
+    /// Environment variable: `BOOKBOSS__OIDC__AUTO_PROVISION`
+    #[serde(default)]
+    pub auto_provision: bool,
 }
 
 impl OidcConfig {
@@ -200,6 +207,7 @@ mod tests {
             client_id: Some("bookboss".into()),
             client_secret: Some("secret".into()),
             button_label: None,
+            auto_provision: false,
         };
         assert!(config.is_set());
         assert!(config.is_sso_available());
@@ -212,6 +220,7 @@ mod tests {
             client_id: None,
             client_secret: None,
             button_label: None,
+            auto_provision: false,
         };
         assert!(config.is_set());
         // Partial config — should log via tracing::error! and return false.

--- a/crates/frontend/src/password.rs
+++ b/crates/frontend/src/password.rs
@@ -17,6 +17,38 @@ pub(crate) fn password_is_valid(pw: &str) -> bool {
     password_requirements(pw).iter().all(|(_, ok)| *ok)
 }
 
+/// Generates a random password that satisfies [`password_is_valid`]: one of
+/// each required character class plus filler, shuffled. Used both for
+/// admin-created accounts and for auto-provisioned SSO accounts (which never
+/// use it, but the `users` table requires a hash).
+#[cfg(feature = "server")]
+pub(crate) fn make_password() -> String {
+    use rand::RngExt;
+
+    const UPPER: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const LOWER: &[u8] = b"abcdefghijklmnopqrstuvwxyz";
+    const DIGITS: &[u8] = b"0123456789";
+    const ALL: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-=[]{}|;:,.<>?";
+
+    let mut rng = rand::rng();
+    // Guarantee one of each required character class.
+    let mut pw: Vec<u8> = vec![
+        UPPER[rng.random_range(0..UPPER.len())],
+        LOWER[rng.random_range(0..LOWER.len())],
+        DIGITS[rng.random_range(0..DIGITS.len())],
+        SPECIAL_CHARS.as_bytes()[rng.random_range(0..SPECIAL_CHARS.len())],
+    ];
+    for _ in pw.len()..16 {
+        pw.push(ALL[rng.random_range(0..ALL.len())]);
+    }
+    // Fisher-Yates shuffle so the guaranteed classes aren't always in front.
+    for i in (1..pw.len()).rev() {
+        let j = rng.random_range(0..=i);
+        pw.swap(i, j);
+    }
+    String::from_utf8(pw).expect("all bytes are valid ASCII")
+}
+
 /// Server-side password strength validation. Returns `Err` with a user-facing
 /// message if the password does not satisfy all requirements.
 #[cfg(feature = "server")]

--- a/crates/frontend/src/routes/settings_page/mod.rs
+++ b/crates/frontend/src/routes/settings_page/mod.rs
@@ -2,6 +2,7 @@ mod application_section;
 mod genre_tags_section;
 mod libraries_section;
 mod messages_section;
+mod oidc_provisioning;
 mod tasks_section;
 mod users_section;
 
@@ -10,6 +11,7 @@ use dioxus::prelude::*;
 use genre_tags_section::GenreTagsSection;
 use libraries_section::LibrariesSection;
 use messages_section::MessagesSection;
+use oidc_provisioning::OidcProvisioningPanel;
 use tasks_section::TasksSection;
 use users_section::UsersSection;
 
@@ -201,6 +203,7 @@ pub(crate) fn SettingsPage() -> Element {
             div { class: "flex-1 overflow-auto p-8 flex flex-col items-center",
                 match active_section() {
                     Section::Users => rsx! {
+                        OidcProvisioningPanel { is_super_admin: context.is_super_admin }
                         UsersSection {
                             is_super_admin: context.is_super_admin,
                             current_user_token: context.current_user_token.clone(),

--- a/crates/frontend/src/routes/settings_page/oidc_provisioning.rs
+++ b/crates/frontend/src/routes/settings_page/oidc_provisioning.rs
@@ -1,0 +1,394 @@
+//! Settings > Users panel to configure the defaults applied to accounts that
+//! are auto-provisioned on first OIDC login. The master on/off switch lives in
+//! the `BOOKBOSS__OIDC__AUTO_PROVISION` env var (surfaced read-only here); this
+//! panel only edits the role/capabilities/libraries/default-library defaults,
+//! persisted via `AppSettingService`.
+
+#[cfg(feature = "server")]
+use bb_core::{CoreServices, types::Capability};
+use dioxus::prelude::*;
+#[cfg(feature = "server")]
+use {
+    crate::routes::server_helpers::authenticated_user,
+    crate::server::{AuthSession, AutoProvisionEnabled},
+    std::sync::Arc,
+};
+
+use super::users_section::{LibraryAssignRow, list_all_libraries_simple};
+
+// ---------------------------------------------------------------------------
+// DTO
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct OidcProvisioningSettings {
+    /// Whether `BOOKBOSS__OIDC__AUTO_PROVISION` is enabled (read-only status).
+    pub enabled_via_env: bool,
+    /// Capability names (`Capability::as_str`) granted to provisioned users.
+    pub capabilities: Vec<String>,
+    /// Library tokens assigned to provisioned users.
+    pub library_tokens: Vec<String>,
+    /// Default library token (empty when unset).
+    pub default_library: String,
+}
+
+// ---------------------------------------------------------------------------
+// Server functions
+// ---------------------------------------------------------------------------
+
+#[post(
+    "/api/v1/settings/oidc-provisioning",
+    auth_session: axum::Extension<AuthSession>,
+    core_services: axum::Extension<Arc<CoreServices>>,
+    auto_provision: axum::Extension<AutoProvisionEnabled>
+)]
+pub(crate) async fn get_oidc_provisioning_settings() -> Result<OidcProvisioningSettings, ServerFnError> {
+    let user = authenticated_user(&auth_session)?;
+    if !user.permissions.contains("SuperAdmin") && !user.permissions.contains("Admin") {
+        return Err(ServerFnError::new("Insufficient permissions"));
+    }
+
+    let AutoProvisionEnabled(enabled_via_env) = *auto_provision;
+
+    let defaults = core_services
+        .app_setting_service
+        .oidc_provisioning_defaults()
+        .await
+        .map_err(|e| ServerFnError::new(e.to_string()))?;
+
+    let capabilities = defaults.capabilities.iter().map(|c| c.as_str().to_string()).collect();
+
+    Ok(OidcProvisioningSettings {
+        enabled_via_env,
+        capabilities,
+        library_tokens: defaults.library_tokens,
+        default_library: defaults.default_library.unwrap_or_default(),
+    })
+}
+
+#[post(
+    "/api/v1/settings/oidc-provisioning/save",
+    auth_session: axum::Extension<AuthSession>,
+    core_services: axum::Extension<Arc<CoreServices>>
+)]
+pub(crate) async fn set_oidc_provisioning_settings(
+    capabilities: Vec<String>,
+    library_tokens: Vec<String>,
+    default_library: String,
+) -> Result<(), ServerFnError> {
+    use bb_core::app_setting::OidcProvisioningDefaults;
+
+    let actor = authenticated_user(&auth_session)?;
+    if !actor.permissions.contains("SuperAdmin") && !actor.permissions.contains("Admin") {
+        return Err(ServerFnError::new("Insufficient permissions"));
+    }
+
+    // Same role rules as manual user creation: never SuperAdmin; Admin only when
+    // the acting admin is a Super Admin.
+    let caps = super::users_section::parse_capabilities(&capabilities)?;
+    if caps.contains(&Capability::SuperAdmin) {
+        return Err(ServerFnError::new("Cannot assign Super Admin role"));
+    }
+    if caps.contains(&Capability::Admin) && !actor.permissions.contains("SuperAdmin") {
+        return Err(ServerFnError::new("Only Super Admin can assign the Admin role"));
+    }
+
+    let default_library = {
+        let trimmed = default_library.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            // A default library that isn't among the assigned libraries can never
+            // be applied at provision time (set_default_library requires the user
+            // to be assigned to it), so reject it here rather than persist a
+            // dangling default.
+            if !library_tokens.iter().any(|t| t == trimmed) {
+                return Err(ServerFnError::new("Default library must be one of the selected libraries"));
+            }
+            Some(trimmed.to_string())
+        }
+    };
+
+    let defaults = OidcProvisioningDefaults {
+        capabilities: caps,
+        library_tokens,
+        default_library,
+    };
+
+    core_services
+        .app_setting_service
+        .set_oidc_provisioning_defaults(&defaults)
+        .await
+        .map_err(|e| ServerFnError::new(e.to_string()))?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// OidcProvisioningPanel component
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, PartialEq)]
+enum RoleChoice {
+    Admin,
+    User,
+}
+
+const GRANTABLE: [(&str, &str); 5] = [
+    ("ApproveImports", "Approve Imports"),
+    ("ConvertBook", "Convert Books"),
+    ("DeleteBook", "Delete Books"),
+    ("EditBook", "Edit Books"),
+    ("OpdsAccess", "OPDS Access"),
+];
+
+#[component]
+pub(crate) fn OidcProvisioningPanel(is_super_admin: bool) -> Element {
+    let mut enabled_via_env = use_signal(|| false);
+    let mut role = use_signal(|| RoleChoice::User);
+    let mut user_caps: Signal<Vec<String>> = use_signal(Vec::new);
+    let mut checked_library_tokens: Signal<Vec<String>> = use_signal(Vec::new);
+    let mut default_library_token = use_signal(String::new);
+    let mut saving = use_signal(|| false);
+    let mut saved = use_signal(|| false);
+    let mut error_msg: Signal<Option<String>> = use_signal(|| None);
+
+    let settings_resource = use_resource(get_oidc_provisioning_settings);
+    // Only fetch libraries once we know provisioning is enabled.
+    let libraries_resource = use_resource(move || async move { if enabled_via_env() { Some(list_all_libraries_simple().await) } else { None } });
+
+    // Populate the form once the stored defaults load.
+    use_effect(move || {
+        if let Some(Ok(s)) = settings_resource() {
+            enabled_via_env.set(s.enabled_via_env);
+            let is_admin_role = s.capabilities.iter().any(|c| c == "Admin");
+            role.set(if is_admin_role { RoleChoice::Admin } else { RoleChoice::User });
+            user_caps.set(
+                s.capabilities
+                    .iter()
+                    .filter(|c| c.as_str() != "Admin" && c.as_str() != "SuperAdmin")
+                    .cloned()
+                    .collect(),
+            );
+            checked_library_tokens.set(s.library_tokens.clone());
+            default_library_token.set(s.default_library.clone());
+        }
+    });
+
+    // Only surface the panel when auto-provisioning is enabled via the env var.
+    // Hidden (fail-closed) until the stored settings confirm it is enabled.
+    if !enabled_via_env() {
+        return rsx! {};
+    }
+
+    rsx! {
+        div { class: "w-full max-w-3xl mb-8",
+            div { class: "rounded-lg border border-gray-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-800",
+                div { class: "mb-4",
+                    h3 { class: "text-base font-semibold text-gray-900 dark:text-slate-100", "OIDC Auto-Provisioning" }
+                    p { class: "text-sm text-gray-500 mt-0.5 dark:text-slate-400",
+                        "Defaults applied to accounts created automatically the first time a user signs in via SSO with an email that has no existing account."
+                    }
+                }
+
+                // Env-gate status (the panel only renders when enabled).
+                div { class: "mb-4 flex items-center gap-2 text-sm text-green-700 dark:text-green-400",
+                    span { "✓" }
+                    span { "Auto-provisioning is enabled via " code { "BOOKBOSS__OIDC__AUTO_PROVISION" } "." }
+                }
+
+                // Role
+                div { class: "mb-4",
+                    label { class: "block text-sm font-medium text-gray-700 mb-1 dark:text-slate-300", "Role" }
+                    select {
+                        class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-hidden focus:ring-2 focus:ring-indigo-500 text-sm bg-white dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100",
+                        disabled: saving(),
+                        onchange: move |e| {
+                            let new_role = if e.value() == "Admin" { RoleChoice::Admin } else { RoleChoice::User };
+                            if new_role == RoleChoice::User {
+                                user_caps.set(Vec::new());
+                            }
+                            role.set(new_role);
+                            saved.set(false);
+                        },
+                        option { value: "User", selected: role() == RoleChoice::User, "User" }
+                        option {
+                            value: "Admin",
+                            selected: role() == RoleChoice::Admin,
+                            disabled: !is_super_admin,
+                            "Admin"
+                        }
+                    }
+                }
+
+                // Capabilities (User role only)
+                if role() == RoleChoice::User {
+                    div { class: "mb-4",
+                        label { class: "block text-sm font-medium text-gray-700 mb-2 dark:text-slate-300", "Capabilities" }
+                        div { class: "space-y-2 rounded-lg border border-gray-200 p-3 dark:border-slate-700",
+                            for (cap_key, cap_label) in GRANTABLE {
+                                {
+                                    let key = cap_key.to_string();
+                                    let key_remove = key.clone();
+                                    let is_checked = user_caps().contains(&key);
+                                    rsx! {
+                                        label { class: "flex items-center gap-2 cursor-pointer select-none",
+                                            input {
+                                                r#type: "checkbox",
+                                                class: "rounded border-gray-300 text-indigo-600 focus:ring-indigo-500",
+                                                checked: is_checked,
+                                                disabled: saving(),
+                                                onchange: move |e| {
+                                                    if e.checked() {
+                                                        user_caps.write().push(key.clone());
+                                                    } else {
+                                                        user_caps.write().retain(|c| c != &key_remove);
+                                                    }
+                                                    saved.set(false);
+                                                },
+                                            }
+                                            span { class: "text-sm text-gray-700 dark:text-slate-300", "{cap_label}" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Libraries
+                div { class: "mb-4",
+                    label { class: "block text-sm font-medium text-gray-700 mb-2 dark:text-slate-300", "Libraries" }
+                    match libraries_resource() {
+                        None | Some(None) => rsx! {
+                            div { class: "text-gray-400 text-xs dark:text-slate-500", "Loading libraries…" }
+                        },
+                        Some(Some(Err(e))) => rsx! {
+                            div { class: "p-2 bg-red-50 border border-red-200 text-red-700 rounded text-xs dark:bg-red-900/30 dark:border-red-800 dark:text-red-400",
+                                "{e}"
+                            }
+                        },
+                        Some(Some(Ok(libs))) => {
+                            let checked = checked_library_tokens();
+                            let all_checked: Vec<LibraryAssignRow> =
+                                libs.iter().filter(|l| checked.contains(&l.token)).cloned().collect();
+                            rsx! {
+                                div { class: "rounded-lg border border-gray-200 p-3 space-y-1.5 max-h-40 overflow-y-auto dark:border-slate-600",
+                                    if libs.is_empty() {
+                                        div { class: "text-xs text-gray-400 dark:text-slate-500", "No libraries configured." }
+                                    }
+                                    for lib in &libs {
+                                        {
+                                            let tok = lib.token.clone();
+                                            let tok_remove = tok.clone();
+                                            let tok_def = tok.clone();
+                                            let is_checked = checked_library_tokens().contains(&tok);
+                                            rsx! {
+                                                label { class: "flex items-center gap-2 cursor-pointer select-none",
+                                                    input {
+                                                        r#type: "checkbox",
+                                                        class: "rounded border-gray-300 text-indigo-600 focus:ring-indigo-500",
+                                                        checked: is_checked,
+                                                        disabled: saving(),
+                                                        onchange: move |e| {
+                                                            if e.checked() {
+                                                                checked_library_tokens.write().push(tok.clone());
+                                                                if default_library_token().is_empty() {
+                                                                    default_library_token.set(tok.clone());
+                                                                }
+                                                            } else {
+                                                                checked_library_tokens.write().retain(|t| t != &tok_remove);
+                                                                if default_library_token() == tok_def {
+                                                                    default_library_token.set(String::new());
+                                                                }
+                                                            }
+                                                            saved.set(false);
+                                                        },
+                                                    }
+                                                    span { class: "text-sm text-gray-700 dark:text-slate-300", "{lib.name}" }
+                                                    if lib.is_system {
+                                                        span { class: "text-xs text-blue-500 font-medium dark:text-blue-400", "(system)" }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                // Default library picker
+                                if !all_checked.is_empty() {
+                                    div { class: "mt-3",
+                                        label { class: "block text-xs font-medium text-gray-600 mb-1 dark:text-slate-400", "Default Library" }
+                                        select {
+                                            class: "w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-hidden focus:ring-2 focus:ring-indigo-500 text-sm bg-white dark:bg-slate-700 dark:border-slate-600 dark:text-slate-100",
+                                            disabled: saving(),
+                                            value: default_library_token,
+                                            onchange: move |e| {
+                                                default_library_token.set(e.value());
+                                                saved.set(false);
+                                            },
+                                            option { value: "", disabled: true, selected: default_library_token().is_empty(), "Select default…" }
+                                            for lib in &all_checked {
+                                                option {
+                                                    value: lib.token.clone(),
+                                                    selected: default_library_token() == lib.token,
+                                                    "{lib.name}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Inline error
+                if let Some(ref msg) = error_msg() {
+                    div { class: "mb-4 p-3 bg-red-50 border border-red-200 text-red-700 rounded-lg text-sm dark:bg-red-900/30 dark:border-red-800 dark:text-red-400",
+                        "{msg}"
+                    }
+                }
+
+                // Actions
+                div { class: "flex items-center justify-end gap-3 pt-2",
+                    if saved() {
+                        span { class: "text-sm text-green-600 dark:text-green-400", "Saved ✓" }
+                    }
+                    button {
+                        class: "px-4 py-2 text-sm font-medium rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50",
+                        disabled: saving(),
+                        onclick: move |_| {
+                            let capabilities: Vec<String> = match role() {
+                                RoleChoice::Admin => vec!["Admin".to_string()],
+                                RoleChoice::User => user_caps(),
+                            };
+                            let lib_tokens = checked_library_tokens();
+                            let def_lib = default_library_token();
+                            error_msg.set(None);
+                            saved.set(false);
+                            saving.set(true);
+                            spawn(async move {
+                                match set_oidc_provisioning_settings(capabilities, lib_tokens, def_lib).await {
+                                    Ok(()) => {
+                                        saving.set(false);
+                                        saved.set(true);
+                                    }
+                                    Err(ServerFnError::ServerError { message, .. }) => {
+                                        error_msg.set(Some(message));
+                                        saving.set(false);
+                                    }
+                                    Err(e) => {
+                                        error_msg.set(Some(e.to_string()));
+                                        saving.set(false);
+                                    }
+                                }
+                            });
+                        },
+                        if saving() { "Saving…" } else { "Save" }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/frontend/src/routes/settings_page/users_section.rs
+++ b/crates/frontend/src/routes/settings_page/users_section.rs
@@ -505,40 +505,11 @@ pub(crate) async fn admin_delete_user(token: String) -> Result<(), ServerFnError
 pub(crate) async fn generate_password() -> Result<String, ServerFnError> {
     authenticated_user(&auth_session)?;
 
-    Ok(make_password())
+    Ok(crate::password::make_password())
 }
 
 #[cfg(feature = "server")]
-fn make_password() -> String {
-    use rand::RngExt;
-
-    const UPPER: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    const LOWER: &[u8] = b"abcdefghijklmnopqrstuvwxyz";
-    const DIGITS: &[u8] = b"0123456789";
-    const SPECIAL: &[u8] = b"!@#$%^&*()_+-=[]{}|;:,.<>?";
-    const ALL: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+-=[]{}|;:,.<>?";
-
-    let mut rng = rand::rng();
-    // Guarantee one of each required character class
-    let mut pw: Vec<u8> = vec![
-        UPPER[rng.random_range(0..UPPER.len())],
-        LOWER[rng.random_range(0..LOWER.len())],
-        DIGITS[rng.random_range(0..DIGITS.len())],
-        SPECIAL[rng.random_range(0..SPECIAL.len())],
-    ];
-    for _ in 4..16 {
-        pw.push(ALL[rng.random_range(0..ALL.len())]);
-    }
-    // Fisher-Yates shuffle
-    for i in (1..pw.len()).rev() {
-        let j = rng.random_range(0..=i);
-        pw.swap(i, j);
-    }
-    String::from_utf8(pw).expect("all bytes are valid ASCII")
-}
-
-#[cfg(feature = "server")]
-fn parse_capabilities(capabilities: &[String]) -> Result<bb_core::types::Capabilities, ServerFnError> {
+pub(super) fn parse_capabilities(capabilities: &[String]) -> Result<bb_core::types::Capabilities, ServerFnError> {
     use std::collections::HashSet;
     let mut caps = HashSet::new();
     for s in capabilities {

--- a/crates/frontend/src/server/mod.rs
+++ b/crates/frontend/src/server/mod.rs
@@ -40,6 +40,13 @@ const REQUEST_ID_HEADER: &str = "x-request-id";
 const DEFAULT_EXPIRATION_DURATION: Duration = Duration::days(7);
 const MAX_REQUEST_BODY_SIZE: usize = 70 * 1024 * 1024; // 70 MiB
 
+/// Server-wide mirror of [`OidcConfig::auto_provision`], exposed as an axum
+/// `Extension` so both the OIDC callback and the admin settings server fns can
+/// read it — even when SSO is not otherwise configured (in which case it is
+/// `false`).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AutoProvisionEnabled(pub bool);
+
 pub struct FrontendSubsystem {
     config: FrontendConfig,
     oidc_config: Option<OidcConfig>,
@@ -121,10 +128,15 @@ impl IntoSubsystem<anyhow::Error> for FrontendSubsystem {
             app_router = app_router.merge(oidc::oidc_router()).layer(Extension(client)).layer(Extension(Arc::new(cfg)));
         }
 
+        // Expose the auto-provision gate to every route (callback + admin server
+        // fns). `false` when SSO is not configured.
+        let auto_provision = AutoProvisionEnabled(self.oidc_config.as_ref().is_some_and(|c| c.auto_provision));
+
         let app_router = app_router
             .layer(Extension(core_services.health_service.clone()))
             .layer(Extension(core_services))
             .layer(Extension(frontend_config))
+            .layer(Extension(auto_provision))
             .layer(middleware);
 
         let health_handler = || async { axum::http::StatusCode::OK };

--- a/crates/frontend/src/server/oidc.rs
+++ b/crates/frontend/src/server/oidc.rs
@@ -235,6 +235,9 @@ async fn start_handler(Extension(client): Extension<Arc<OidcClient>>) -> axum::r
         )
         .add_scope(Scope::new("openid".to_string()))
         .add_scope(Scope::new("email".to_string()))
+        // `profile` gives us `preferred_username` / `name` for provisioned
+        // accounts; harmless for the match-by-email path.
+        .add_scope(Scope::new("profile".to_string()))
         .set_pkce_challenge(pkce_challenge)
         .url();
 
@@ -255,6 +258,7 @@ async fn start_handler(Extension(client): Extension<Arc<OidcClient>>) -> axum::r
 async fn callback_handler(
     Extension(client): Extension<Arc<OidcClient>>,
     Extension(core_services): Extension<Arc<bb_core::CoreServices>>,
+    Extension(auto_provision): Extension<super::AutoProvisionEnabled>,
     auth_session: super::AuthSession,
     Query(query): Query<CallbackQuery>,
 ) -> axum::response::Response {
@@ -365,15 +369,36 @@ async fn callback_handler(
         }
     };
 
-    // ── Look up BookBoss user ─────────────────────────────────────────────
+    // ── Look up BookBoss user (auto-provision if enabled) ─────────────────
     let user = match core_services.auth_service.is_valid_email(&email).await {
         Ok(Some(u)) => u,
         Ok(None) => {
-            tracing::error!(
-                email = %email,
-                "OIDC callback: no BookBoss user with this email — check that a BookBoss user has this exact email_address (case-sensitive)"
-            );
-            return failure_redirect();
+            if !auto_provision.0 {
+                tracing::error!(
+                    email = %email,
+                    "OIDC callback: no BookBoss user with this email — check that a BookBoss user has this exact email_address (case-sensitive)"
+                );
+                return failure_redirect();
+            }
+            // Prefer IdP-provided identity (requires the `profile` scope); fall
+            // back to the email local-part inside `provision_user`.
+            let preferred_username = claims.preferred_username().map(|u| u.as_str().to_string());
+            let full_name_hint = claims.name().and_then(|n| n.get(None)).map(|n| n.as_str().to_string());
+            match provision_user(&core_services, &email, preferred_username, full_name_hint).await {
+                Ok(u) => {
+                    tracing::info!(
+                        username = %u.username,
+                        email = %email,
+                        sub = %claims.subject().as_str(),
+                        "OIDC callback: auto-provisioned new user"
+                    );
+                    u
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, email = %email, "OIDC callback: auto-provisioning failed");
+                    return failure_redirect();
+                }
+            }
         }
         Err(e) => {
             tracing::error!(error = %e, "OIDC callback: user lookup failed");
@@ -389,4 +414,91 @@ async fn callback_handler(
 
 fn failure_redirect() -> axum::response::Response {
     Redirect::to("/?login_failed=1").into_response()
+}
+
+/// Auto-provisions a BookBoss account for an OIDC login with no matching local
+/// user, applying the defaults configured under Settings > Users.
+///
+/// `preferred_username` / `full_name_hint` come from the IdP (`profile` scope);
+/// both fall back to the email local-part. The generated password is never used
+/// (SSO accounts authenticate via the IdP) but satisfies the `users` schema.
+async fn provision_user(
+    core: &bb_core::CoreServices,
+    email: &bb_core::types::EmailAddress,
+    preferred_username: Option<String>,
+    full_name_hint: Option<String>,
+) -> Result<bb_core::user::User, bb_core::Error> {
+    use bb_core::{library::LibraryToken, types::Capability, user::NewUser};
+
+    let defaults = core.app_setting_service.oidc_provisioning_defaults().await?;
+
+    // Enforce the documented invariant at the trust boundary: SuperAdmin is never
+    // auto-provisioned, whatever the stored defaults happen to contain.
+    let mut capabilities = defaults.capabilities.clone();
+    capabilities.remove(&Capability::SuperAdmin);
+
+    let local_part = email.as_str().split('@').next().unwrap_or_else(|| email.as_str()).to_string();
+    let base_username = preferred_username
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| local_part.clone());
+    let full_name = full_name_hint
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| base_username.clone());
+
+    let username = unique_username(core, &base_username).await?;
+
+    let new_user = NewUser::new(
+        username,
+        crate::password::make_password(),
+        email.as_str(),
+        capabilities,
+        full_name,
+        // SSO accounts never log in with a password, so never force a change
+        // (which would otherwise trap the user with no password form to fill).
+        false,
+    )?;
+    let user = core.user_service.add_user(new_user).await?;
+
+    // Assign the configured libraries (best-effort). The user row is already
+    // committed, so a failing assignment must not abort with `?`: doing so would
+    // leave a half-provisioned account that the next login skips re-provisioning
+    // for (is_valid_email now matches), stranding it permanently. A stale/deleted
+    // but well-formed token would otherwise brick every future provisioning.
+    for token_str in &defaults.library_tokens {
+        if let Ok(token) = token_str.parse::<LibraryToken>() {
+            if let Err(e) = core.library_service.assign_library_to_user(user.id, token).await {
+                tracing::warn!(error = %e, token = %token_str, "OIDC provisioning: could not assign library; skipping");
+            }
+        } else {
+            tracing::warn!(token = %token_str, "OIDC provisioning: skipping malformed library token");
+        }
+    }
+
+    // Set the default library (best-effort — a bad default must not block an
+    // otherwise-successful provisioning; it falls back to All Books).
+    if let Some(default_str) = defaults.default_library.as_deref() {
+        if let Ok(token) = default_str.parse::<LibraryToken>() {
+            if let Err(e) = core.library_service.set_default_library(user.id, token).await {
+                tracing::warn!(error = %e, "OIDC provisioning: could not set default library; falling back to All Books");
+            }
+        } else {
+            tracing::warn!(token = %default_str, "OIDC provisioning: malformed default library token");
+        }
+    }
+
+    Ok(user)
+}
+
+/// Finds a free username derived from `base`, appending `2`, `3`, … on
+/// collision (usernames are matched case-insensitively).
+async fn unique_username(core: &bb_core::CoreServices, base: &str) -> Result<String, bb_core::Error> {
+    for suffix in 0..1000u32 {
+        let candidate = if suffix == 0 { base.to_string() } else { format!("{base}{}", suffix + 1) };
+        if core.user_service.find_by_username(&candidate).await?.is_none() {
+            return Ok(candidate);
+        }
+    }
+    Err(bb_core::Error::Validation(format!("could not derive a unique username from '{base}'")))
 }


### PR DESCRIPTION
Hi,

To streamline onboarding of new users on Bookboss, this PR allows to auto provision users and to configure default role, capabilities, and libraries.

This is disabled by default, and needs to be enabled with BOOKBOSS__OIDC__AUTO_PROVISION=true

<img width="1264" height="794" alt="2026-07-21_18:02:12_screenshot" src="https://github.com/user-attachments/assets/6b57c8ff-2546-4b6b-a58d-32060b2962b4" />

It uses the profile scope to fetch the user's name.
Tested with Authentik.